### PR TITLE
Batch minimization

### DIFF
--- a/src/foscat/scat_cov.py
+++ b/src/foscat/scat_cov.py
@@ -3520,6 +3520,20 @@ class funct(FOC.FoCUS):
             return self.backend.bk_reduce_mean(x)
         return result
 
+    def reduce_mean_batch(self, x):
+        if isinstance(x, scat_cov):
+            result = scat_cov()
+            # Assuming the batch dimension is the first dimension
+            result.S0 = self.backend.bk_reduce_mean(x.S0, axis=0)
+            result.P00 = self.backend.bk_reduce_mean(x.P00, axis=0)
+            if x.S1 is not None:
+                result.S1 = self.backend.bk_reduce_mean(x.S1, axis=0)
+            result.C01 = self.backend.bk_reduce_mean(x.C01, axis=0)
+            result.C11 = self.backend.bk_reduce_mean(x.C11, axis=0)
+            return result
+        else:
+            return self.backend.bk_reduce_mean(x, axis=0)
+    
     def reduce_distance(self, x, y, sigma=None):
 
         if isinstance(x, scat_cov):

--- a/src/foscat/scat_cov.py
+++ b/src/foscat/scat_cov.py
@@ -3375,7 +3375,7 @@ class funct(FOC.FoCUS):
             tmp2 = self.backend.bk_repeat(MconvPsi, 4, axis=-1)
             MconvPsi = self.backend.bk_reduce_sum(
                 self.backend.bk_reshape(
-                    cmat2[j3][j2] * tmp2, [1, cmat2[j3].shape[1], 4, 4, 4]
+                    cmat2[j3][j2] * tmp2, [tmp2.shape[0], cmat2[j3].shape[1], 4, 4, 4]
                 ),
                 3,
             )

--- a/src/foscat/scat_cov.py
+++ b/src/foscat/scat_cov.py
@@ -2694,7 +2694,7 @@ class funct(FOC.FoCUS):
                 tmp2 = self.backend.bk_repeat(conv1, 4, axis=-1)
                 conv1 = self.backend.bk_reduce_sum(
                     self.backend.bk_reshape(
-                        cmat[j3] * tmp2, [1, cmat[j3].shape[0], 4, 4]
+                        cmat[j3] * tmp2, [tmp2.shape[0], cmat[j3].shape[0], 4, 4]
                     ),
                     2,
                 )
@@ -2800,7 +2800,7 @@ class funct(FOC.FoCUS):
                     tmp2 = self.backend.bk_repeat(conv2, 4, axis=-1)
                     conv2 = self.backend.bk_reduce_sum(
                         self.backend.bk_reshape(
-                            cmat[j3] * tmp2, [1, cmat[j3].shape[0], 4, 4]
+                            cmat[j3] * tmp2, [tmp2.shape[0], cmat[j3].shape[0], 4, 4]
                         ),
                         2,
                     )


### PR DESCRIPTION
Modified scat_cov.py  to allow for batch minimization. Now `eval` can be called directly on a batch of maps. Added also a function `reduce_mean_batch` to be called for example in a loss function to compute efficiently the mean of the scattering coefficient on a batch of maps at each iteration in gradient descent.